### PR TITLE
Fix shared banner reuse and widget day rollover reset

### DIFF
--- a/DrinkWell.xcodeproj/project.pbxproj
+++ b/DrinkWell.xcodeproj/project.pbxproj
@@ -606,7 +606,7 @@
 				CODE_SIGN_ENTITLEMENTS = DrinkWellWidgetExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = 7Z7PC435F7;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DrinkWellWidget/Info.plist;
@@ -618,7 +618,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = hilalNisanci.DrinkWell.DrinkWellWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -638,7 +638,7 @@
 				CODE_SIGN_ENTITLEMENTS = DrinkWellWidgetExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = 7Z7PC435F7;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DrinkWellWidget/Info.plist;
@@ -650,7 +650,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = hilalNisanci.DrinkWell.DrinkWellWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -791,7 +791,7 @@
 				CODE_SIGN_ENTITLEMENTS = DrinkWell/DrinkWell.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_ASSET_PATHS = "\"DrinkWell/Preview Content\"";
 				DEVELOPMENT_TEAM = 7Z7PC435F7;
 				ENABLE_PREVIEWS = YES;
@@ -809,7 +809,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = hilalNisanci.DrinkWell;
 				PRODUCT_NAME = DrinkWell;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -828,7 +828,7 @@
 				CODE_SIGN_ENTITLEMENTS = DrinkWell/DrinkWell.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_ASSET_PATHS = "\"DrinkWell/Preview Content\"";
 				DEVELOPMENT_TEAM = 7Z7PC435F7;
 				ENABLE_PREVIEWS = YES;
@@ -846,7 +846,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = hilalNisanci.DrinkWell;
 				PRODUCT_NAME = DrinkWell;
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/DrinkWell/Info.plist
+++ b/DrinkWell/Info.plist
@@ -18,7 +18,9 @@
 	<key>GADApplicationIdentifier</key>
 	<string>ca-app-pub-2543228431265950~1319517185</string>
 	<key>GADBannerAdUnitID</key>
-	<string>ca-app-pub-3940256099942544/2435281174</string>
+	<string>ca-app-pub-2543228431265950/5767497268</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>SKAdNetworkItems</key>
 	<array>
 		<dict>

--- a/DrinkWell/ViewModels/WaterViewModel.swift
+++ b/DrinkWell/ViewModels/WaterViewModel.swift
@@ -9,12 +9,21 @@ import Foundation
 import SwiftUI
 import SwiftData
 import WidgetKit
+import UIKit
 
 @MainActor
 class WaterViewModel: ObservableObject {
     // Access via DataController
     private let dataController = DataController.shared
     private let preferences = UserPreferences.shared
+    private var dayChangeObserverTokens: [NSObjectProtocol] = []
+
+    private enum WidgetStorageKeys {
+        static let suiteName = "group.com.hilalNisanci.DrinkWell"
+        static let todaysIntake = "todaysIntake"
+        static let dailyGoal = "dailyGoal"
+        static let todaysIntakeDayStart = "todaysIntakeDayStart"
+    }
 
     private enum WaterViewModelError: LocalizedError {
         case loadFailed
@@ -81,11 +90,8 @@ class WaterViewModel: ObservableObject {
             self.dailyGoal = 2500
             UserDefaults.standard.set(self.dailyGoal, forKey: "dailyGoal")
         }
-        
-        // Set initial values for the widget
-        let userDefaults = UserDefaults(suiteName: "group.com.hilalNisanci.DrinkWell")
-        userDefaults?.set(todaysTotal, forKey: "todaysIntake")
-        userDefaults?.set(dailyGoal, forKey: "dailyGoal")
+
+        syncWidgetSnapshot(reloadTimeline: false)
 
         // Load data
         Task {
@@ -93,6 +99,7 @@ class WaterViewModel: ObservableObject {
         }
 
         NotificationCenter.default.addObserver(self, selector: #selector(refreshData), name: .themeDidChange, object: nil)
+        setupDayChangeObservers()
     }
 
     @objc private func refreshData() {
@@ -101,8 +108,44 @@ class WaterViewModel: ObservableObject {
         }
     }
 
+    private func setupDayChangeObservers() {
+        let notifications: [Notification.Name] = [
+            .NSCalendarDayChanged,
+            UIApplication.significantTimeChangeNotification,
+            UIApplication.willEnterForegroundNotification
+        ]
+
+        dayChangeObserverTokens = notifications.map { name in
+            NotificationCenter.default.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.handleCalendarBoundaryChange()
+                }
+            }
+        }
+    }
+
+    private func handleCalendarBoundaryChange() {
+        let calendar = Calendar.current
+        let now = Date()
+        let currentStoredDayStart = calendar.startOfDay(for: currentDate)
+        let actualDayStart = calendar.startOfDay(for: now)
+
+        guard currentStoredDayStart != actualDayStart else {
+            return
+        }
+
+        currentDate = now
+        objectWillChange.send()
+        syncWidgetSnapshot(reloadTimeline: true)
+
+        Task {
+            await loadWaterIntakes()
+        }
+    }
+
     deinit {
         NotificationCenter.default.removeObserver(self)
+        dayChangeObserverTokens.forEach { NotificationCenter.default.removeObserver($0) }
     }
 
     // MARK: - Data Handling Methods
@@ -117,6 +160,7 @@ class WaterViewModel: ObservableObject {
             await MainActor.run {
                 self.waterIntakes = fetchedIntakes
             }
+            syncWidgetSnapshot(reloadTimeline: false)
         } catch {
             print("❌ Error: Failed to load water intakes: \(error.localizedDescription)")
         }
@@ -144,11 +188,26 @@ class WaterViewModel: ObservableObject {
             return []
         }
     }
-    
+
+    private func syncWidgetSnapshot(reloadTimeline: Bool) {
+        guard let userDefaults = UserDefaults(suiteName: WidgetStorageKeys.suiteName) else { return }
+
+        let dayStart = Calendar.current.startOfDay(for: currentDate)
+        userDefaults.set(todaysTotal, forKey: WidgetStorageKeys.todaysIntake)
+        userDefaults.set(dailyGoal, forKey: WidgetStorageKeys.dailyGoal)
+        userDefaults.set(dayStart.timeIntervalSince1970, forKey: WidgetStorageKeys.todaysIntakeDayStart)
+
+        if reloadTimeline {
+            WidgetCenter.shared.reloadAllTimelines()
+        }
+    }
+
     // MARK: - Core Functions
     
     /// Adds a new water intake
     func addWaterIntake(amount: Double, note: String? = nil) async {
+        handleCalendarBoundaryChange()
+
         let newIntake = WaterIntake(amount: amount, timestamp: currentDate, note: note)
         
         dataController.insert(newIntake)
@@ -162,16 +221,12 @@ class WaterViewModel: ObservableObject {
         }
         
         objectWillChange.send()
-
-        // Update the widget
-        let userDefaults = UserDefaults(suiteName: "group.com.hilalNisanci.DrinkWell")
-        userDefaults?.set(todaysTotal, forKey: "todaysIntake")
-        userDefaults?.set(dailyGoal, forKey: "dailyGoal")
-        WidgetCenter.shared.reloadAllTimelines()
+        syncWidgetSnapshot(reloadTimeline: true)
     }
     
     /// Deletes a specific water intake
     func removeWaterIntake(at offsets: IndexSet) async {
+        handleCalendarBoundaryChange()
         let todaysIntakes = await fetchTodaysIntakes()
         
         for index in offsets {
@@ -193,12 +248,7 @@ class WaterViewModel: ObservableObject {
         }
         
         objectWillChange.send()
-
-        // Update the widget
-        let userDefaults = UserDefaults(suiteName: "group.com.hilalNisanci.DrinkWell")
-        userDefaults?.set(todaysTotal, forKey: "todaysIntake")
-        userDefaults?.set(dailyGoal, forKey: "dailyGoal")
-        WidgetCenter.shared.reloadAllTimelines()
+        syncWidgetSnapshot(reloadTimeline: true)
     }
     
     /// Handles date changes
@@ -210,6 +260,8 @@ class WaterViewModel: ObservableObject {
     /// Updates the daily goal
     func updateDailyGoal(_ newGoal: Double) {
         preferences.dailyGoal = newGoal
+        dailyGoal = newGoal
+        syncWidgetSnapshot(reloadTimeline: true)
         objectWillChange.send()
     }
 }

--- a/DrinkWell/Views/BannerAdView.swift
+++ b/DrinkWell/Views/BannerAdView.swift
@@ -7,106 +7,133 @@ struct BannerAdView: UIViewRepresentable {
     init(adUnitID: String) {
         self.adUnitID = adUnitID
     }
-    
-    func makeCoordinator() -> Coordinator {
-        Coordinator(self)
-    }
-    
+
     func makeUIView(context: Context) -> BannerView {
-        let bannerView = context.coordinator.bannerView
+        let bannerView = SharedBannerAdService.shared.bannerView(for: adUnitID)
         bannerView.backgroundColor = .clear
         return bannerView
     }
-    
+
     func updateUIView(_ uiView: BannerView, context: Context) {
-        if uiView.rootViewController == nil {
-            uiView.rootViewController = uiView.window?.rootViewController
-        }
-        context.coordinator.updateBanner(rootViewController: uiView.window?.rootViewController)
+        SharedBannerAdService.shared.updateBanner(
+            adUnitID: adUnitID,
+            rootViewController: uiView.window?.rootViewController
+        )
     }
-    
-    class Coordinator: NSObject, BannerViewDelegate {
-        private var parent: BannerAdView
-        private var isRequestInFlight = false
-        
-        private(set) lazy var bannerView: BannerView = {
-            let banner = BannerView()
-            banner.adUnitID = parent.adUnitID
-            // Keep a compact, classic bottom banner size on iPhone.
-            banner.adSize = AdSizeBanner
-            banner.delegate = self
-            return banner
-        }()
-        
-        init(_ parent: BannerAdView) {
-            self.parent = parent
+}
+
+final class SharedBannerAdService: NSObject, BannerViewDelegate {
+    static let shared = SharedBannerAdService()
+
+    private var isRequestInFlight = false
+    private var hasLoadedAd = false
+    private var lastLoadedAdUnitID: String?
+
+    private lazy var sharedBannerView: BannerView = {
+        let banner = BannerView()
+        banner.adSize = AdSizeBanner
+        banner.delegate = self
+        banner.backgroundColor = .clear
+        return banner
+    }()
+
+    private override init() {
+        super.init()
+    }
+
+    func bannerView(for adUnitID: String) -> BannerView {
+        if sharedBannerView.adUnitID != adUnitID {
+            sharedBannerView.adUnitID = adUnitID
+            hasLoadedAd = false
+            lastLoadedAdUnitID = nil
         }
 
-        func updateBanner(rootViewController: UIViewController?) {
-            if bannerView.rootViewController == nil {
-                bannerView.rootViewController = rootViewController ?? currentRootViewController()
-            }
-
-            if bannerView.adUnitID != parent.adUnitID {
-                bannerView.adUnitID = parent.adUnitID
-            }
-
-            if !isRequestInFlight, bannerView.rootViewController != nil {
-                isRequestInFlight = true
-                bannerView.load(Request())
-            }
+        if sharedBannerView.superview != nil {
+            sharedBannerView.removeFromSuperview()
         }
 
-        private func currentRootViewController() -> UIViewController? {
-            UIApplication.shared.connectedScenes
-                .compactMap { $0 as? UIWindowScene }
-                .flatMap(\.windows)
-                .first(where: { $0.isKeyWindow })?
-                .rootViewController
+        return sharedBannerView
+    }
+
+    func updateBanner(adUnitID: String, rootViewController: UIViewController?) {
+        if sharedBannerView.adUnitID != adUnitID {
+            sharedBannerView.adUnitID = adUnitID
+            hasLoadedAd = false
+            lastLoadedAdUnitID = nil
         }
-        
-        // MARK: - BannerViewDelegate
-        func bannerViewDidReceiveAd(_ bannerView: BannerView) {
-            isRequestInFlight = false
-            #if DEBUG
-            print("Banner ad successfully loaded")
-            #endif
+
+        if sharedBannerView.rootViewController == nil {
+            sharedBannerView.rootViewController = rootViewController ?? currentRootViewController()
+        } else if rootViewController != nil {
+            sharedBannerView.rootViewController = rootViewController
         }
-        
-        func bannerView(_ bannerView: BannerView, didFailToReceiveAdWithError error: Error) {
-            isRequestInFlight = false
-            #if DEBUG
-            print("Failed to load banner ad: \(error.localizedDescription)")
-            #endif
-            // Retry once after a short delay when placement has no immediate fill.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
-                guard let self else { return }
-                self.updateBanner(rootViewController: self.bannerView.rootViewController)
-            }
+
+        let needsLoad = !hasLoadedAd || lastLoadedAdUnitID != adUnitID
+        guard !isRequestInFlight, needsLoad, sharedBannerView.rootViewController != nil else {
+            return
         }
-        
-        func bannerViewDidRecordImpression(_ bannerView: BannerView) {
-            #if DEBUG
-            print("Banner impression recorded")
-            #endif
+
+        isRequestInFlight = true
+        sharedBannerView.load(Request())
+    }
+
+    private func currentRootViewController() -> UIViewController? {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .first(where: { $0.isKeyWindow })?
+            .rootViewController
+    }
+
+    // MARK: - BannerViewDelegate
+    func bannerViewDidReceiveAd(_ bannerView: BannerView) {
+        isRequestInFlight = false
+        hasLoadedAd = true
+        lastLoadedAdUnitID = bannerView.adUnitID
+        #if DEBUG
+        print("Banner ad successfully loaded")
+        #endif
+    }
+
+    func bannerView(_ bannerView: BannerView, didFailToReceiveAdWithError error: Error) {
+        isRequestInFlight = false
+        hasLoadedAd = false
+        #if DEBUG
+        print("Failed to load banner ad: \(error.localizedDescription)")
+        #endif
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+            guard
+                let self,
+                let adUnitID = bannerView.adUnitID,
+                !adUnitID.isEmpty
+            else { return }
+
+            self.updateBanner(adUnitID: adUnitID, rootViewController: bannerView.rootViewController)
         }
-        
-        func bannerViewWillPresentScreen(_ bannerView: BannerView) {
-            #if DEBUG
-            print("Banner will present full-screen content")
-            #endif
-        }
-        
-        func bannerViewWillDismissScreen(_ bannerView: BannerView) {
-            #if DEBUG
-            print("Banner will dismiss full-screen content")
-            #endif
-        }
-        
-        func bannerViewDidDismissScreen(_ bannerView: BannerView) {
-            #if DEBUG
-            print("Banner dismissed full-screen content")
-            #endif
-        }
+    }
+
+    func bannerViewDidRecordImpression(_ bannerView: BannerView) {
+        #if DEBUG
+        print("Banner impression recorded")
+        #endif
+    }
+
+    func bannerViewWillPresentScreen(_ bannerView: BannerView) {
+        #if DEBUG
+        print("Banner will present full-screen content")
+        #endif
+    }
+
+    func bannerViewWillDismissScreen(_ bannerView: BannerView) {
+        #if DEBUG
+        print("Banner will dismiss full-screen content")
+        #endif
+    }
+
+    func bannerViewDidDismissScreen(_ bannerView: BannerView) {
+        #if DEBUG
+        print("Banner dismissed full-screen content")
+        #endif
     }
 }

--- a/DrinkWell/Views/ContentView.swift
+++ b/DrinkWell/Views/ContentView.swift
@@ -16,9 +16,9 @@ struct ContentView: View {
     @StateObject private var preferences = UserPreferences.shared
 
     var body: some View {
-        TabView(selection: $selectedTab) {
-            // MAIN SCREEN
-            VStack(spacing: 0) {
+        VStack(spacing: 0) {
+            TabView(selection: $selectedTab) {
+                // MAIN SCREEN
                 NavigationStack {
                     VStack(spacing: 0) {
                         // Progress indicator
@@ -145,33 +145,26 @@ struct ContentView: View {
                             await viewModel.loadWaterIntakes()
                         }
                     }
+                }.tabItem {
+                    Label("home_tab".localized, systemImage: "house.fill")
                 }
-                BottomBannerAdContainer()
-            }
-            .tabItem {
-                Label("home_tab".localized, systemImage: "house.fill")
-            }
-            .tag(0)
-            
-            // STATISTICS PAGE
-            VStack(spacing: 0) {
+                .tag(0)
+                
+                // STATISTICS PAGE
                 StatsView()
-                BottomBannerAdContainer()
-            }
                 .tabItem {
                     Label("stats_tab".localized, systemImage: "chart.bar.fill")
                 }
                 .tag(1)
-            
-            // SETTINGS PAGE
-            VStack(spacing: 0) {
+                
+                // SETTINGS PAGE
                 SettingsView(selectedTab: $selectedTab)
-                BottomBannerAdContainer()
-            }
                 .tabItem {
                     Label("settings_tab".localized, systemImage: "gearshape.fill")
                 }
                 .tag(2)
+            }
+            BottomBannerAdContainer()
         }
         .onAppear {
             // Set TabBar appearance to appropriate color

--- a/DrinkWellWidget/DrinkWellWidget.swift
+++ b/DrinkWellWidget/DrinkWellWidget.swift
@@ -15,15 +15,28 @@ struct Provider: TimelineProvider {
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<WaterEntry>) -> ()) {
         let userDefaults = UserDefaults(suiteName: "group.com.hilalNisanci.DrinkWell")
-
-        let intake = userDefaults?.double(forKey: "todaysIntake") ?? 0
+        let storedIntake = userDefaults?.double(forKey: "todaysIntake") ?? 0
         let goal = userDefaults?.double(forKey: "dailyGoal") ?? 2500
+        let calendar = Calendar.current
+        let startOfToday = calendar.startOfDay(for: Date())
+        let storedDayStart = (userDefaults?.object(forKey: "todaysIntakeDayStart") as? Double)
+            .map { Date(timeIntervalSince1970: $0) }
+
+        let intake: Double
+        if let storedDayStart, calendar.isDate(storedDayStart, inSameDayAs: startOfToday) {
+            intake = storedIntake
+        } else {
+            intake = 0
+            userDefaults?.set(0, forKey: "todaysIntake")
+            userDefaults?.set(startOfToday.timeIntervalSince1970, forKey: "todaysIntakeDayStart")
+        }
 
         print("Widget Timeline - Intake: \(intake), Goal: \(goal)")
         
         let entry = WaterEntry(date: Date(), intake: intake, goal: goal)
-        
-        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: Date()) ?? Date()
+
+        let startOfTomorrow = calendar.date(byAdding: .day, value: 1, to: startOfToday) ?? Date().addingTimeInterval(60 * 60 * 24)
+        let nextUpdate = calendar.date(byAdding: .minute, value: 1, to: startOfTomorrow) ?? startOfTomorrow
         let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
         
         completion(timeline)


### PR DESCRIPTION
## Summary
- Reworked banner handling to use a single shared banner instance and moved banner placement to one global bottom container across tabs.
- Added widget snapshot sync in WaterViewModel with todaysIntakeDayStart tracking.
- Added day-boundary observers (NSCalendarDayChanged, significant time change, foreground) to refresh app/widget state.
- Updated widget timeline to validate day key and auto-refresh right after next day starts.
- Bumped version/build to 1.0.3 (6) and included existing release metadata updates in Info.plist.

## Test Steps
- xcodebuild -workspace DrinkWell.xcworkspace -scheme DrinkWell -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.0.1' build
- xcodebuild -workspace DrinkWell.xcworkspace -scheme DrinkWell -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.0.1' -only-testing:DrinkWellTests test
- Manual:
  - Load banner in Home, switch to Stats/Settings, verify no banner re-creation flicker/reload.
  - Simulate day rollover and verify widget resets to 0 ml without requiring a new intake entry.
  - Add a new intake after rollover and verify widget updates immediately.

## Risk Notes
- Banner is now a shared singleton view; unexpected ad SDK lifecycle edge cases could affect reload behavior after long background periods.
- Widget now resets stale intake if day key is missing/mismatched; immediately after upgrade, users may briefly see 0 until app writes fresh snapshot.
